### PR TITLE
CallChain: Better support for class namespaces in GUI and DOT representation

### DIFF
--- a/CallChain.py
+++ b/CallChain.py
@@ -64,13 +64,13 @@ def print_call_chain(call_chain, dot):
         function_name=sanitize_dot(function)
 
         if function == call_chain[0]:
-            dot.node(function_name, function_name, style='filled',
+            dot.node(function_name, str(function), style='filled',
                      color='blue', fontcolor='white')
         elif function == call_chain[-1]:
-            dot.node(function_name, function_name, style='filled',
+            dot.node(function_name, str(function), style='filled',
                      color='red', fontcolor='white')
         else:
-            dot.node(function_name, function_name)
+            dot.node(function_name, str(function))
         if previous_function:
             previous_function_name=sanitize_dot(previous_function)
             dot.edge(previous_function_name, function_name)

--- a/CallChain.py
+++ b/CallChain.py
@@ -40,6 +40,11 @@ def get_references(caller, callee):
     return ref_list
 
 def sanitize_dot(func):
+    """
+    Return a sanitized function name string compatible with DOT representation.
+
+    :param func: Function object
+    """
     return str(func).replace("::","\\")
 
 def print_call_chain(call_chain, dot):

--- a/CallChain.py
+++ b/CallChain.py
@@ -39,6 +39,8 @@ def get_references(caller, callee):
 
     return ref_list
 
+def sanitize_dot(func):
+    return str(func).replace("::","\\")
 
 def print_call_chain(call_chain, dot):
     """
@@ -54,16 +56,19 @@ def print_call_chain(call_chain, dot):
     for function in call_chain:
         references = []
 
+        function_name=sanitize_dot(function)
+
         if function == call_chain[0]:
-            dot.node(str(function), str(function), style='filled',
+            dot.node(function_name, function_name, style='filled',
                      color='blue', fontcolor='white')
         elif function == call_chain[-1]:
-            dot.node(str(function), str(function), style='filled',
+            dot.node(function_name, function_name, style='filled',
                      color='red', fontcolor='white')
         else:
-            dot.node(str(function), str(function))
+            dot.node(function_name, function_name)
         if previous_function:
-            dot.edge(str(previous_function), str(function))
+            previous_function_name=sanitize_dot(previous_function)
+            dot.edge(previous_function_name, function_name)
             function_references[str(previous_function)] = get_references(
                 previous_function, function)
 
@@ -117,7 +122,7 @@ def discover_call_chain(from_function, to_function):
 
 func_man = currentProgram.getFunctionManager()
 function_list = [function for function in func_man.getFunctions(True)]
-function_list.sort(key=lambda func: func.name)
+function_list.sort(key=lambda func: str(func))
 
 from_function = askChoice('Select function',
                           'Select the starting function',


### PR DESCRIPTION
When working with programs with class namespaces it's more convenient to order the lists on the GUI based on the fully qualified names of the function, that include the class namespace too. 

Extending this to graphing is a bit problematic, because colons have a special meaning Graphviz, so putting "SomeClass::someFunc()" in the graph will produce weird results. I also introduced a function name sanitizer to handle this.